### PR TITLE
fix: select column str addressed

### DIFF
--- a/src/tidyversetopandas/tidyversetopandas.py
+++ b/src/tidyversetopandas/tidyversetopandas.py
@@ -37,7 +37,7 @@ def select(dataframe, *columns):
 
     Parameters:
     dataframe (pd.DataFrame): The DataFrame to select columns from.
-    columns (list of str): Column names to select.
+    columns (str): Column names to select.
 
     Returns:
     pd.DataFrame: A DataFrame with only the selected columns.


### PR DESCRIPTION
In the docstring for the select function, *columns should not be a list of str. Addressed.